### PR TITLE
Refactor: Group work experience items into a single box on About page

### DIFF
--- a/src/About.tsx
+++ b/src/About.tsx
@@ -29,15 +29,18 @@ const About: React.FC = () => {
     <div className="home-section">
       <div className="work-experience">
         <h2>Work Experience</h2>
-        <div className="experience-list">
+        <div className="experience-list single-box"> {/* Added a class for potential styling */}
           {workExperience.map((job, index) => (
-            <div key={index} className="experience-item">
-              <div className="experience-header">
-                <h3>{job.company}</h3>
-                <span className="period">{job.period}</span>
+            <React.Fragment key={index}> {/* Using React.Fragment to avoid extra divs if not needed for styling */}
+              <div className="experience-item"> {/* Retaining this class for individual item styling */}
+                <div className="experience-header">
+                  <h3>{job.company}</h3>
+                  <span className="period">{job.period}</span>
+                </div>
+                <p>{job.description}</p>
               </div>
-              <p>{job.description}</p>
-            </div>
+              {index < workExperience.length - 1 && <hr className="experience-separator" />} {/* Optional: Add a separator */}
+            </React.Fragment>
           ))}
         </div>
       </div>

--- a/src/App.css
+++ b/src/App.css
@@ -120,6 +120,62 @@
   gap: 2rem;
 }
 
+/* Styles for when work experiences are grouped into a single box */
+.experience-list.single-box {
+  display: block; /* Override grid display */
+  background: rgba(0, 0, 0, 0.2); /* Apply box styling to the container */
+  backdrop-filter: blur(10px);
+  border: 1px solid rgba(100, 181, 246, 0.2);
+  border-radius: 1rem;
+  padding: 2rem; /* Padding for the single box */
+  /* gap is not needed here as items flow normally or use margins */
+}
+
+.experience-list.single-box .experience-item {
+  /* Remove individual box styling as the parent .single-box now has it */
+  background: none;
+  backdrop-filter: none;
+  border: none;
+  padding: 0; /* Remove padding, rely on margins or container padding */
+  margin-bottom: 1.5rem; /* Add some space between items within the box */
+  position: relative; /* Keep for ::before if still desired, or remove */
+  overflow: visible; /* Adjust if ::before was causing issues */
+}
+
+.experience-list.single-box .experience-item:last-child {
+  margin-bottom: 0; /* No margin for the last item */
+}
+
+/* Keep ::before for the main single-box container instead of individual items */
+.experience-list.single-box::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 4px;
+  height: 100%;
+  background: linear-gradient(180deg, #64b5f6, #2196f3);
+  border-radius: 1rem 0 0 1rem; /* Adjust to match container's border-radius */
+}
+
+.experience-list.single-box .experience-item::before {
+  display: none; /* Hide ::before for individual items inside single-box */
+}
+
+.experience-list.single-box .experience-item:hover {
+  /* Adjust hover effects if needed, or remove if they don't make sense for items within a box */
+  transform: none;
+  border-color: none;
+  box-shadow: none;
+}
+
+hr.experience-separator {
+  border: none;
+  height: 1px;
+  background-color: rgba(100, 181, 246, 0.2);
+  margin: 1.5rem 0;
+}
+
 .experience-item {
   background: rgba(0, 0, 0, 0.2);
   backdrop-filter: blur(10px);


### PR DESCRIPTION
Modified About.tsx to render all work experience entries within a single parent div.

Updated App.css to:
- Add styles for the '.experience-list.single-box' container, transferring the box-like appearance (background, border, padding) to it.
- Adjust styles for '.experience-item' when inside '.single-box' to remove redundant individual boxing and rely on the parent for the overall box effect.
- Add styling for 'hr.experience-separator' for visual separation between job entries within the single box.