### PR TITLE
feat: Use HashRouter instead of BrowserRouter

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom'
+import { HashRouter as Router, Routes, Route, Link } from 'react-router-dom'
 import Profile from './Profile'
 import Blog from './Blog'
 import About from './About'


### PR DESCRIPTION
Switched from BrowserRouter to HashRouter in App.tsx to ensure compatibility with GitHub Pages and other static hosting environments that may not support server-side routing.